### PR TITLE
FIX:単語カード追加時に、追加した単語が表示されない不具合を改善

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,9 +4,11 @@ import ModalController from "./modal_controller"
 import TimerController from "./timer_controller"
 import GameController from "./game_controller"
 import ScoreController from "./score_controller"
+import WordCardsPreviewController from "./word_cards_preview_controller"
 
 application.register("hello", HelloController)
 application.register("modal", ModalController)
 application.register("timer", TimerController)
 application.register("game", GameController)
 application.register("score", ScoreController)
+application.register("word-cards-preview", WordCardsPreviewController)

--- a/app/javascript/controllers/word_cards_preview_controller.js
+++ b/app/javascript/controllers/word_cards_preview_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["form", "liveCards", "english", "japanese"]
+
+  connect() {
+    this.formTarget.addEventListener("submit", e => this.addCard(e))
+  }
+
+  addCard(e) {
+    if (e.submitter && e.submitter.name === 'finished') return;
+    e.preventDefault()
+
+    const english = this.englishTarget.value.trim()
+    const japanese = this.japaneseTarget.value.trim()
+    if (!english || !japanese) return
+
+    const cardDiv = document.createElement('div')
+    cardDiv.className = 'card'
+    cardDiv.innerHTML = `<p><strong>${english}</strong> - ${japanese}</p>`
+    this.liveCardsTarget.appendChild(cardDiv)
+
+    this.englishTarget.value = ''
+    this.japaneseTarget.value = ''
+  }
+}

--- a/app/views/word_cards/new.html.erb
+++ b/app/views/word_cards/new.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, "ゲームキット新規作成 | VocaBoom!" %>
 
+<div data-controller="word-cards-preview"
+     data-word-cards-preview-target="liveCards">
+
 <h1>ゲームカード追加</h1>
 
 <p>英単語と日本語を入力してください</p>
@@ -30,3 +33,12 @@
     <%= f.submit "カードを追加する" %>
     <%= f.submit "完成！", name: 'finished'%>
   <% end %>
+
+  <div id="live-cards" data-word-cards-preview-target="liveCards">
+    <% @word_kit.word_cards.each do |card| %>
+      <div class="card">
+        <p><strong><%= card.english_word %></strong> - <%= card.japanese_translation %></p>
+      </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
## 変更内容

ワードキット新規作成時、ワードカードを追加した際に、追加された単語が表示されなかったので、表示されるようにした
