### PR TITLE
FIX:単語カード編集画面のUXの見直し

### DIFF
--- a/app/controllers/word_kits_controller.rb
+++ b/app/controllers/word_kits_controller.rb
@@ -30,6 +30,11 @@ class WordKitsController < ApplicationController
   end
 
   def show
+    @word_kit = current_user.word_kits.find(params[:id])
+    @questions = @word_kit.word_cards
+  end
+
+  def play
     @game_room = GameRoom.find(params[:game_room_id])
     @word_kit = @game_room.word_kit
     @questions = @word_kit.word_cards
@@ -46,20 +51,25 @@ class WordKitsController < ApplicationController
   def edit
      @word_kit = current_user.word_kits.find(params[:id])
      @word_cards = @word_kit.word_cards
+     @word_card = @word_kit.word_cards.build
   end
 
   def update
     @word_kit = current_user.word_kits.find(params[:id])
+
     if @word_kit.update(word_kit_params)
-      redirect_to word_kit_path(@word_kit)
+      redirect_to word_kits_path, notice: '更新しました'
     else
-      render :edit
+      redirect_to word_kits_path, alert: '変更はありませんでした'
     end
   end
 
   private
 
   def word_kit_params
-    params.require(:word_kit).permit(:name)
+    params.require(:word_kit).permit(
+      :name,
+      word_cards_attributes: [:id, :english_word, :japanese_translation, :_destroy]
+    )
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,6 +5,7 @@ import TimerController from "./timer_controller"
 import GameController from "./game_controller"
 import ScoreController from "./score_controller"
 import WordCardsPreviewController from "./word_cards_preview_controller"
+import NestedCardsController from "./nested_cards_controller"
 
 application.register("hello", HelloController)
 application.register("modal", ModalController)
@@ -12,3 +13,4 @@ application.register("timer", TimerController)
 application.register("game", GameController)
 application.register("score", ScoreController)
 application.register("word-cards-preview", WordCardsPreviewController)
+application.register("nested-cards", NestedCardsController)

--- a/app/javascript/controllers/nested_cards_controller.js
+++ b/app/javascript/controllers/nested_cards_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["container"]
+
+  add() {
+    const time = new Date().getTime()
+
+    const html = `
+      <div class="card-row">
+        <input type="text"
+               name="word_kit[word_cards_attributes][${time}][english_word]"
+               placeholder="英単語"
+               class="english-input">
+
+        <input type="text"
+               name="word_kit[word_cards_attributes][${time}][japanese_translation]"
+               placeholder="日本語"
+               class="japanese-input">
+      </div>
+    `
+
+    this.containerTarget.insertAdjacentHTML("beforeend", html)
+
+    const lastCard = this.containerTarget.lastElementChild
+
+    lastCard.scrollIntoView({ behavior: "smooth", block: "center" })
+
+    const englishInput = lastCard.querySelector(".english-input")
+    if (englishInput) englishInput.focus()
+  }
+}

--- a/app/models/word_kit.rb
+++ b/app/models/word_kit.rb
@@ -1,5 +1,6 @@
 class WordKit < ApplicationRecord
   has_many :word_cards, dependent: :destroy
+  accepts_nested_attributes_for :word_cards, allow_destroy: true
   has_many :game_rooms, dependent: :destroy
   belongs_to :user
 

--- a/app/views/word_kits/edit.html.erb
+++ b/app/views/word_kits/edit.html.erb
@@ -2,22 +2,41 @@
 
 <h1>キット編集</h1>
 
-<%= form_with model: @word_kit do |f| %>
+<%= form_with model: @word_kit, local: true, data: { turbo: false } do |f| %>
+
   <div>
+    <h3>キット名</h3>
     <%= f.text_field :name %>
   </div>
-  <%= f.submit "更新" %>
-<% end %>
 
-<ul>
-<% @word_kit.word_cards.each do |card| %>
-  <li>
-    <%= card.english_word %>
-    <%= card.japanese_translation %>
-    <%= link_to '削除', word_kit_word_card_path(@word_kit, card), data: { turbo_method: :delete } %>
-    <%= link_to '編集', edit_word_kit_word_card_path(@word_kit, card) %>
-  </li>
-<% end %>
-</ul>
+  <hr>
 
-<%= link_to 'ゲームキット一覧画面へ', word_kits_path %>
+  <h3>登録済みの単語</h3>
+
+  <div id="existing-cards" data-nested-cards-target="container">
+    <%= f.fields_for :word_cards do |card_form| %>
+      <div class="card-row">
+        <%= card_form.hidden_field :id %>
+
+        <%= card_form.text_field :english_word, placeholder: "英単語" %>
+        <%= card_form.text_field :japanese_translation, placeholder: "日本語" %>
+
+        <label>
+          削除
+          <%= card_form.check_box :_destroy %>
+        </label>
+      </div>
+    <% end %>
+  </div>
+
+  <hr>
+
+  <button type="button" data-action="nested-cards#add">
+    ＋ 単語を追加
+  </button>
+
+  <hr>
+
+  <%= f.submit "更新！" %>
+
+<% end %>

--- a/app/views/word_kits/index.html.erb
+++ b/app/views/word_kits/index.html.erb
@@ -8,6 +8,7 @@
         <%= kit.name %>
         <%= link_to '削除', word_kit_path(kit), data: { turbo_method: :delete, confirm: "削除しますか？" } %>
         <%= link_to '編集', edit_word_kit_path(kit) %>
+        <%= link_to "詳細", word_kit_path(kit) %>
         
         <%= button_to 'このゲームで遊ぶ！', game_rooms_path(word_kit_id: kit.id), method: :post, data: { turbo: false } %>
       </li>

--- a/app/views/word_kits/show.html.erb
+++ b/app/views/word_kits/show.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "ゲームキット詳細 | VocaBoom!" %>
+
+<h1><%= @word_kit.name %></h1>
+
+<ul>
+  <% @questions.each do |card| %>
+    <li><%= card.english_word %> - <%= card.japanese_translation %></li>
+  <% end %>
+</ul>
+
+<%= link_to "編集", edit_word_kit_path(@word_kit) %>
+<%= link_to "一覧へ戻る", word_kits_path %>


### PR DESCRIPTION
## 変更内容

・現状→単語編集画面で単語の追加ができなかった。削除のみできた

・今回→単語キット、単語削除、単語の追加が１つの画面でできるようにした
　　　→詳細画面の作成