### PR TITLE
FIX:ワードカード上書き保存ができない問題を修正

### DIFF
--- a/app/controllers/word_kits_controller.rb
+++ b/app/controllers/word_kits_controller.rb
@@ -56,12 +56,12 @@ class WordKitsController < ApplicationController
   def update
     @word_kit = current_user.word_kits.find(params[:id])
 
-    @word_kit.assign_attributes(word_kit_params)
-
-    if !@word_kit.changed?
-      redirect_to word_kits_path, notice: '変更はありませんでした'
-    elsif @word_kit.save
-      redirect_to word_kits_path, notice: '更新しました'
+    if @word_kit.update(word_kit_params)
+      if @word_kit.saved_changes?
+        redirect_to word_kits_path, notice: '更新しました'
+      else
+        redirect_to word_kits_path, notice: '変更はありませんでした'
+      end
     else
       render :edit, status: :unprocessable_entity
     end


### PR DESCRIPTION
## 変更内容

ワードカードが上書き保存でいない問題を解決

1. 追加して、セーブ
2. 変更があったら「更新されました」
3. 変更がなかったら「変更はありませんでした」