### PR TITLE
FIX:タイマーが２秒加算される問題を修正。サーバーとブラウザの時間差がマイナスにならないように

### DIFF
--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
     }
     
     const startTime = new Date(this.startedAtValue).getTime()
-    const elapsed = Math.floor((Date.now() - startTime) / 1000)
+    const elapsed = Math.max(0, Math.floor((Date.now() - startTime) / 1000))
     let remaining = Math.max(0, this.timeLimitValue - elapsed)
 
     this.updateDisplay(remaining)


### PR DESCRIPTION
## 変更内容

タイマーが２秒加算される問題を修正

## 原因
サーバーとブラウザの時刻が微妙にズレており、
ゲーム開始時刻（started_at）がブラウザのDate.now()より
未来になるケースがあった。

その結果、経過時間（elapsed）がマイナスになり、
残り時間が設定より多く計算されていた。

## 修正
elapsedが0未満にならないようMath.max(0, elapsed)で補正した。

## 補足
ローカル環境ではサーバーとブラウザが同じマシンで動くため
時刻が一致しており、再現しなかった。