### PR TITLE
FIX:コミュニティのゲームキットが複製されないバグを修正

### DIFF
--- a/app/controllers/word_kits_controller.rb
+++ b/app/controllers/word_kits_controller.rb
@@ -2,7 +2,8 @@
 
 class WordKitsController < ApplicationController
   before_action :require_login
-  before_action :set_word_kit, only: %i[destroy show edit update copy]
+  before_action :set_word_kit, only: %i[destroy show edit update]
+  before_action :set_any_word_kit, only: %i[copy]
 
   def index
     @word_kits = current_user.word_kits.left_outer_joins(:tags)
@@ -86,6 +87,10 @@ class WordKitsController < ApplicationController
 
   def set_word_kit
     @word_kit = current_user.word_kits.find_by!(uuid: params[:uuid])
+  end
+
+  def set_any_word_kit
+    @word_kit = WordKit.find_by!(uuid: params[:uuid])
   end
 
   def word_kit_params

--- a/app/controllers/word_kits_controller.rb
+++ b/app/controllers/word_kits_controller.rb
@@ -90,7 +90,7 @@ class WordKitsController < ApplicationController
   end
 
   def set_any_word_kit
-    @word_kit = WordKit.find_by!(uuid: params[:uuid])
+    @word_kit = WordKit.find_by!(uuid: params[:uuid], visibility: 'public_kit')
   end
 
   def word_kit_params

--- a/spec/requests/word_kits_spec.rb
+++ b/spec/requests/word_kits_spec.rb
@@ -183,30 +183,32 @@ RSpec.describe 'WordKits', type: :request do
   end
 
   describe 'POST #copy' do
+    let!(:public_kit) { WordKit.create!(name: '公開キット', user: other_user, visibility: 'public_kit') }
+
     before do
-      word_kit.word_cards.create!(english_word: 'apple', japanese_translation: 'りんご')
+      public_kit.word_cards.create!(english_word: 'apple', japanese_translation: 'りんご')
     end
 
     it '複製されたWordKitが作成されること' do
       expect do
-        post copy_word_kit_path(word_kit)
+        post copy_word_kit_path(public_kit)
       end.to change(WordKit, :count).by(1)
     end
 
     it '複製されたキットの名前に「copy」が含まれること' do
-      post copy_word_kit_path(word_kit)
+      post copy_word_kit_path(public_kit)
       copied = WordKit.last
       expect(copied.name).to include('copy')
     end
 
     it '複製されたキットはprivate_kitになること' do
-      post copy_word_kit_path(word_kit)
+      post copy_word_kit_path(public_kit)
       copied = WordKit.last
       expect(copied.visibility).to eq('private_kit')
     end
 
     it '複製されたキットのページにリダイレクトされること' do
-      post copy_word_kit_path(word_kit)
+      post copy_word_kit_path(public_kit)
       copied = WordKit.last
       expect(response).to redirect_to(word_kit_path(copied))
     end


### PR DESCRIPTION
## 変更内容
コミュニティのゲームキットが複製されないバグを修正

## 原因
set_word_kitがcurrent_user.word_kitsで絞り込んでいたため、他のユーザーのWordKitを複製しようとすると自分のword_kitsの中に存在せず404になっていた。

## 対策
set_word_kitではなく、set_any_word_kitにて公開設定がpublicの全てのWordKitのuuidを参照することで、複製を可能にする。