### PR TITLE
FIX:ワードキットを複製するときにタグがないことを修正

### DIFF
--- a/app/models/word_kit.rb
+++ b/app/models/word_kit.rb
@@ -41,6 +41,9 @@ class WordKit < ApplicationRecord
         japanese_translation: card.japanese_translation
       )
     end
+
+    new_kit.tags = tags
+
     new_kit
   end
 

--- a/app/views/community/show.html.erb
+++ b/app/views/community/show.html.erb
@@ -30,6 +30,14 @@
       <% end %>
     </ul>
 
+    <div class="edit-section-title">タグ</div>
+      <% if @word_kit.tags.any? %>
+        <div class="tag-list-row show-page">
+          <% @word_kit.tags.each do |tag| %>
+            <span class="tag-badge-v2"><%= tag.name %></span>
+          <% end %>
+        </div>
+      <% end %>
   </div>
 
 </div>


### PR DESCRIPTION
## 変更内容

ワードキットを複製するときにタグがないことを修正

## 原因
①コミュニティーのキットの詳細表示にタグがなかったこと
②コピーするときに単語だけでタグはコピーしていなかったこと

## 対策
①コミュニティのワードキット詳細画面にタグを表示
②コピーの際にタグを持ってくるように修正
