### PR TITLE
FIX:サーバーが落ちるので、workersの数を制限

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,13 +21,15 @@ if rails_env == 'production'
   #
   # It defaults to 1 because it's impossible to reliably detect how many
   # CPU cores are available. Make sure to set the `WEB_CONCURRENCY` environment
-  # variable to match the number of processors.
-  worker_count = Integer(ENV.fetch('WEB_CONCURRENCY', 1))
-  if worker_count > 1
-    workers worker_count
-  else
-    preload_app!
-  end
+  # # variable to match the number of processors.
+  # worker_count = Integer(ENV.fetch('WEB_CONCURRENCY', 1))
+  # if worker_count > 1
+  #   workers worker_count
+  # else
+  #   preload_app!
+  # end
+  workers 0
+  preload_app!
 end
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.


### PR DESCRIPTION
## 変更内容

サーバーが落ちるので、workersの数を0に変更
